### PR TITLE
Import from django_nine if present

### DIFF
--- a/examples/simple/settings/base.py
+++ b/examples/simple/settings/base.py
@@ -2,7 +2,7 @@
 import os
 import sys
 
-from nine import versions
+from django_nine import versions
 
 from .core import PROJECT_DIR, gettext
 

--- a/examples/simple/urls.py
+++ b/examples/simple/urls.py
@@ -4,7 +4,7 @@ from django.contrib.staticfiles.urls import staticfiles_urlpatterns
 from django.conf.urls.static import static
 from django.contrib import admin
 
-from nine.versions import DJANGO_GTE_2_0
+from django_nine.versions import DJANGO_GTE_2_0
 
 admin.autodiscover()
 

--- a/src/admin_timeline/compat.py
+++ b/src/admin_timeline/compat.py
@@ -1,4 +1,7 @@
-from nine.versions import DJANGO_LTE_1_4
+try:
+    from django_nine import versions as django_versions
+except ImportError:
+    from nine import versions as django_versions
 
 __title__ = 'admin_timeline.compat'
 __author__ = 'Artur Barseghyan <artur.barseghyan@gmail.com>'
@@ -13,6 +16,6 @@ __all__ = (
 TEMPLATE_NAME = "admin_timeline/timeline.html"
 TEMPLATE_NAME_AJAX = "admin_timeline/timeline_ajax.html"
 
-if DJANGO_LTE_1_4:
+if django_versions.DJANGO_LTE_1_4:
     TEMPLATE_NAME = "admin_timeline/django_lte14/timeline.html"
     TEMPLATE_NAME_AJAX = "admin_timeline/django_lte14/timeline_ajax.html"

--- a/src/admin_timeline/templatetags/admin_timeline_tags.py
+++ b/src/admin_timeline/templatetags/admin_timeline_tags.py
@@ -1,13 +1,13 @@
 from django import template
 
-from nine.versions import DJANGO_GTE_1_7, DJANGO_GTE_1_10
+from ..compat import django_versions
 
-if DJANGO_GTE_1_7:
+if django_versions.DJANGO_GTE_1_7:
     from django.contrib.admin.utils import quote
 else:
     from django.contrib.admin.util import quote
 
-if DJANGO_GTE_1_10:
+if django_versions.DJANGO_GTE_1_10:
     from django.urls import reverse, NoReverseMatch
 else:
     from django.core.urlresolvers import reverse, NoReverseMatch

--- a/src/admin_timeline/tests/test_core.py
+++ b/src/admin_timeline/tests/test_core.py
@@ -44,7 +44,10 @@ if os.environ.get("DJANGO_SETTINGS_MODULE", None):
     # ************************************************************************
     # **************** Safe User import for Django > 1.5, < 1.8 **************
     # ************************************************************************
-    from nine.user import User
+    try:
+        from django_nine.user import User
+    except ImportError:
+        from nine.user import User
 
     from foo.models import FooItem, Foo2Item, Foo3Item, Foo4Item
 

--- a/src/admin_timeline/views.py
+++ b/src/admin_timeline/views.py
@@ -12,9 +12,7 @@ from django.utils.translation import ugettext_lazy as _
 from django.views.decorators.cache import never_cache
 from django.views.decorators.csrf import csrf_exempt
 
-from nine import versions
-
-from .compat import TEMPLATE_NAME, TEMPLATE_NAME_AJAX
+from .compat import TEMPLATE_NAME, TEMPLATE_NAME_AJAX, django_versions
 from .forms import FilterForm
 from .settings import (
     NUMBER_OF_ENTRIES_PER_PAGE,
@@ -23,7 +21,7 @@ from .settings import (
     SIMPLE_FILTER_FORM,
 )
 
-if versions.DJANGO_GTE_1_10:
+if django_versions.DJANGO_GTE_1_10:
     from django.shortcuts import render
 else:
     from django.shortcuts import render_to_response


### PR DESCRIPTION
`django_nine` is the new directory/import name
for django-nine, as there is another package `nine`
which uses `nine` directory.